### PR TITLE
replace underscores in the 'chunk_group' docs URLs to be dashes

### DIFF
--- a/guides/recommending-with-trieve.mdx
+++ b/guides/recommending-with-trieve.mdx
@@ -6,7 +6,7 @@ icon: 'circle-user'
 
 ## Overview
 
-We provide the ability to get recommended chunks similar to your data through the [get recommended chunks route](/api-reference/chunk/get-recommended-chunks) or through the [get recommended groups route](/api-reference/chunk_group/get-recommended-groups).
+We provide the ability to get recommended chunks similar to your data through the [get recommended chunks route](/api-reference/chunk/get-recommended-chunks) or through the [get recommended groups route](/api-reference/chunk-group/get-recommended-groups).
 
 ## Different Recommendation Types
 We have two different recommendation types:

--- a/guides/searching-with-trieve.mdx
+++ b/guides/searching-with-trieve.mdx
@@ -6,7 +6,7 @@ icon: 'magnifying-glass'
 
 ## Overview
 
-We provide the ability for you to search your data in a fast and performant manner. We have multiple search paradigms, which are exposed through the [search over chunks route](/api-reference/chunk/search), the [search within groups route](/api-reference/chunk_group/search-within-group), and the [search over groups route](/api-reference/chunk_group/search-over-groups).
+We provide the ability for you to search your data in a fast and performant manner. We have multiple search paradigms, which are exposed through the [search over chunks route](/api-reference/chunk/search), the [search within groups route](/api-reference/chunk-group/search-within-group), and the [search over groups route](/api-reference/chunk-group/search-over-groups).
 
 ## Different Search Paradigms
 


### PR DESCRIPTION
See the links to the `chunk_group` route docs on: 
https://docs.trieve.ai/guides/searching-with-trieve
https://docs.trieve.ai/guides/recommending-with-trieve

They currently fail. This PR fixes those links.

Note: While the API reference documentation uses dashes (ex. https://docs.trieve.ai/api-reference/chunk-group/create-or-upsert-group-or-groups) for the URLs, the `chunk_group` API route itself underscores (ex. `url = "https://api.trieve.ai/api/chunk_group"`).

