### PR TITLE
Add link to Trieve HN Discovery under demos and add links to blogposts for each demo.

### DIFF
--- a/getting-started/introduction.mdx
+++ b/getting-started/introduction.mdx
@@ -26,9 +26,15 @@ With Trieve, you can build and deploy a ChatGPT like experience or a search engi
 
 ### Demos of Trieve in Action
 
+- [Trieve HN Discovery](https://hn.trieve.ai)
+    - [📝 Launching Trieve HN Discovery - A Discovery Focused Search Engine for Hacker News](https://trieve.ai/launching-trieve-hn-discovery/)
 - [YCombinator Companies Search](https://yc.trieve.ai)
+    - [📝 Building Search For the YC Company Directory With Trieve, Bun, and SolidJS
+](https://trieve.ai/building-search-for-yc-company-directory/)
 - [SteamDB Search](https://steamdb.trieve.ai)
+    - [📝 Introducing Yet Another Steam Recommendation Engine!](https://trieve.ai/steam-recommendations)
 - **This documentation site itself!** (and all Mintlify documentation sites)
+    - [📝 Success Story: Mintlify](https://trieve.ai/success-story-mintlify/)
 
 If you are interested in a managed instance and/or SLA, reach out to us by emailing humans@trieve.ai.
 


### PR DESCRIPTION
I'm not sold fully on the presentation of the blogpost links, but very useful to users to have readily accessible links:
<img width="753" alt="image" src="https://github.com/user-attachments/assets/bd81ffdd-2bce-4ecd-aef1-f4a1dfe9c4ef">
